### PR TITLE
Enable in-place linting, and apply to codebase

### DIFF
--- a/autosplit/main.cpp
+++ b/autosplit/main.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 int main() {
-    std::cout << "Hello, world!" << std::endl;
+  std::cout << "Hello, world!" << std::endl;
 
-    return 0;
+  return 0;
 }

--- a/tools/lint/BUILD
+++ b/tools/lint/BUILD
@@ -10,7 +10,7 @@ py_binary(
     main = "lint.py",
     args = [
         "--lint-executable='clang-format'",
-        "--language='cpp'"
+        "--language='cpp'",
     ] + LINT_PATHS,
     deps = [
         "//tools:print",

--- a/tools/print.py
+++ b/tools/print.py
@@ -1,8 +1,8 @@
-from typing import Generator
+from typing import List
 
 from termcolor import colored, cprint
 
-def print_diff(diff: Generator[str, None, None]) -> None:
+def print_diff(diff: List[str]) -> None:
     for diff_line in diff:
         if diff_line[:4] in ['--- ', '+++ ']:
             print(colored(diff_line, attrs=["bold"]))


### PR DESCRIPTION
`bazel run //tools/lint:clang_format -- -i`